### PR TITLE
fix(apps/web): Search result content highlighting when token length <= 3 characters

### DIFF
--- a/apps/web/src/common/typesense.ts
+++ b/apps/web/src/common/typesense.ts
@@ -51,16 +51,24 @@ export async function searchPosts(query: string, postType?: PostType): Promise<S
                     return;
                 }
 
-                highlight.matched_tokens?.forEach((token) => {
-                    if (typeof token !== "string" || token.length <= 3) {
-                        return;
-                    }
-
-                    htmlContent = htmlContent.replace(
-                        token,
-                        `<span class="highlight">${token}</span>`
+                // Prefer the Typesense-generated snippet if available
+                if (highlight.snippet) {
+                    htmlContent = highlight?.snippet.replaceAll(
+                        "<mark>",
+                        '<mark class="highlight">'
                     );
-                });
+                } else {
+                    highlight.matched_tokens?.forEach((token) => {
+                        if (typeof token !== "string" || token.length <= 3) {
+                            return;
+                        }
+
+                        htmlContent = htmlContent.replace(
+                            token,
+                            `<span class="highlight">${token}</span>`
+                        );
+                    });
+                }
             });
 
             return {

--- a/apps/web/src/routes/+page.server.ts
+++ b/apps/web/src/routes/+page.server.ts
@@ -1,41 +1,56 @@
 import { getDatabaseClient } from "@repo/core/dist";
-import type { PostType } from "@repo/core/generated/prisma-client";
+import type { PostType, Post } from "@repo/core/generated/prisma-client";
 import { handleSubmit } from "../common/formActions.js";
 
-export async function load({ url, setHeaders }) {
-    const db = getDatabaseClient();
+export async function load({ url, setHeaders }): Promise<{
+    websiteCount: number;
+    defaultPosts: Post[];
+}> {
+    let websiteCount: number = 0;
+    let defaultPosts: Post[] = [];
 
-    const postTypeFilter = (url.searchParams.get("filter")?.toUpperCase() as PostType) || "IDEAS";
-    const defaultPosts = await db.post.findMany({
-        where: {
-            type: postTypeFilter
-        },
-        orderBy: [
-            {
-                updatedAt: "desc"
+    try {
+        const db = getDatabaseClient();
+
+        const postTypeFilter =
+            (url.searchParams.get("filter")?.toUpperCase() as PostType) || "IDEAS";
+
+        defaultPosts = await db.post.findMany({
+            where: {
+                type: postTypeFilter
             },
-            {
-                domain: "desc"
+            orderBy: [
+                {
+                    updatedAt: "desc"
+                },
+                {
+                    domain: "desc"
+                }
+            ],
+            take: postTypeFilter ? 15 : 9
+        });
+
+        console.log(defaultPosts.length);
+
+        websiteCount = await db.scrapeState.count({
+            where: {
+                status: "SCRAPED",
+                type: "ABOUT"
             }
-        ],
-        take: postTypeFilter ? 15 : 9
-    });
-
-    console.log(defaultPosts.length);
-
-    const websiteCount = await db.scrapeState.count({
-        where: {
-            status: "SCRAPED",
-            type: "ABOUT"
-        }
-    });
+        });
+    } catch (error) {
+        console.error(error);
+    }
 
     // Cache for 1 hour
     setHeaders({
         "Cache-Control": "max-age=0, s-max-age=3600"
     });
 
-    return { websiteCount, defaultPosts };
+    return {
+        websiteCount,
+        defaultPosts
+    };
 }
 
 export const actions = {


### PR DESCRIPTION
## Summary

Within search results, ensures that all text matching the query is highlighted.

## Changes

- 40d01efcb13901864c481a74a59d626fa4b5536c: Allows the application to be started without a database connection
- a6fe1dabd83b896eaf5854f91552468c20b54674: Prefer the results snippet generated by Typesense; fallback to the present implementation if snippet is not present.  It's unclear to me why `token.length <= 3` is present on :62 but this is causing the dropped highlights.

## Screenshots

### Before

<img width="1176" alt="image" src="https://github.com/lindylearn/aboutideasnow/assets/8657791/d79ce8e0-7733-491b-9e3d-9a0a2a6c5dae">

### After

<img width="1186" alt="image" src="https://github.com/lindylearn/aboutideasnow/assets/8657791/09e0cba5-8136-4d4e-8051-a5fd9c88aba6">