### PR TITLE
Update Typesense API host / public key in `.env.example`

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,7 +1,7 @@
 ########### Public secrets ###########
 
-PUBLIC_TYPESENSE_URL="r4v6k8o1npdbix2mp-1.a1.typesense.net"
-PUBLIC_TYPESENSE_SEARCH_API_KEY="dR5vFpxIuIehoPjtKRadH3dVPeFvwSVy"
+PUBLIC_TYPESENSE_URL="ho2mpjftqge4u1xap-1.a1.typesense.net"
+PUBLIC_TYPESENSE_SEARCH_API_KEY="tQy66wTpiGciSP7HSOtVMqTv43VNEDVe"
 
 ########### Private secrets ###########
 


### PR DESCRIPTION
## Summary

It appears that the Typesense API host / public key was updated but the example env wasn't.

## Fixes

- Requests with the host / key that's currently in `.env.example` fail.

## Changes

- I pulled the updated values from production and tested that they work in my development environment.